### PR TITLE
Add manual sys functions where GIR is incorrect

### DIFF
--- a/conf/gir-glib.toml
+++ b/conf/gir-glib.toml
@@ -127,6 +127,14 @@ status = "generate"
     is_windows_utf8 = true
 
 [[object]]
+name = "GLib.KeyFile"
+status = "generate"
+    [[object.function]]
+    pattern = "set_.*_list"
+    # incorrect GIR due to gobject-introspection GitLab issue #189
+    ignore = true
+
+[[object]]
 name = "GLib.Pid"
 status = "manual"
 

--- a/conf/gir-gobject.toml
+++ b/conf/gir-gobject.toml
@@ -11,3 +11,15 @@ ignore = [
    "GObject.VaClosureMarshal",
    "GObject.SignalCVaMarshaller",
 ]
+
+[[object]]
+name = "GObject.Object"
+status = "generate"
+    [[object.function]]
+    pattern = "(get|set)v"
+    # incorrect GIR due to gobject-introspection GitLab issue #189
+    ignore = true
+    [[object.function]]
+    name = "new_with_properties"
+    # incorrect GIR due to gobject-introspection GitLab issue #189
+    ignore = true

--- a/conf/gir-gtk.toml
+++ b/conf/gir-gtk.toml
@@ -25,3 +25,16 @@ ignore = [
 	"Gtk.MICRO_VERSION",
 	"Gtk.MINOR_VERSION",
 ]
+
+
+[[object]]
+name = "Gtk.IconTheme"
+status = "generate"
+    [[object.function]]
+    pattern = "(get|set)_search_path"
+    # incorrect GIR due to gobject-introspection GitLab issue #189
+    ignore = true
+    [[object.function]]
+    pattern = "choose_icon.*"
+    # incorrect GIR due to gobject-introspection GitLab issue #189
+    ignore = true

--- a/glib-sys/src/lib.rs
+++ b/glib-sys/src/lib.rs
@@ -2643,18 +2643,13 @@ extern "C" {
     #[cfg(any(feature = "v2_40", feature = "dox"))]
     pub fn g_key_file_save_to_file(key_file: *mut GKeyFile, filename: *const c_char, error: *mut *mut GError) -> gboolean;
     pub fn g_key_file_set_boolean(key_file: *mut GKeyFile, group_name: *const c_char, key: *const c_char, value: gboolean);
-    pub fn g_key_file_set_boolean_list(key_file: *mut GKeyFile, group_name: *const c_char, key: *const c_char, list: gboolean, length: size_t);
     pub fn g_key_file_set_comment(key_file: *mut GKeyFile, group_name: *const c_char, key: *const c_char, comment: *const c_char, error: *mut *mut GError) -> gboolean;
     pub fn g_key_file_set_double(key_file: *mut GKeyFile, group_name: *const c_char, key: *const c_char, value: c_double);
-    pub fn g_key_file_set_double_list(key_file: *mut GKeyFile, group_name: *const c_char, key: *const c_char, list: c_double, length: size_t);
     pub fn g_key_file_set_int64(key_file: *mut GKeyFile, group_name: *const c_char, key: *const c_char, value: i64);
     pub fn g_key_file_set_integer(key_file: *mut GKeyFile, group_name: *const c_char, key: *const c_char, value: c_int);
-    pub fn g_key_file_set_integer_list(key_file: *mut GKeyFile, group_name: *const c_char, key: *const c_char, list: c_int, length: size_t);
     pub fn g_key_file_set_list_separator(key_file: *mut GKeyFile, separator: c_char);
     pub fn g_key_file_set_locale_string(key_file: *mut GKeyFile, group_name: *const c_char, key: *const c_char, locale: *const c_char, string: *const c_char);
-    pub fn g_key_file_set_locale_string_list(key_file: *mut GKeyFile, group_name: *const c_char, key: *const c_char, locale: *const c_char, list: *mut c_char, length: size_t);
     pub fn g_key_file_set_string(key_file: *mut GKeyFile, group_name: *const c_char, key: *const c_char, string: *const c_char);
-    pub fn g_key_file_set_string_list(key_file: *mut GKeyFile, group_name: *const c_char, key: *const c_char, list: *mut c_char, length: size_t);
     pub fn g_key_file_set_uint64(key_file: *mut GKeyFile, group_name: *const c_char, key: *const c_char, value: u64);
     pub fn g_key_file_set_value(key_file: *mut GKeyFile, group_name: *const c_char, key: *const c_char, value: *const c_char);
     pub fn g_key_file_to_data(key_file: *mut GKeyFile, length: *mut size_t, error: *mut *mut GError) -> *mut c_char;

--- a/glib-sys/src/manual.rs
+++ b/glib-sys/src/manual.rs
@@ -3,7 +3,8 @@
 // Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
 
 #[allow(unused_imports)]
-use libc::{c_int, c_ushort, c_void};
+use libc::{c_char, c_double, c_int, c_ushort, c_void, size_t};
+use {GKeyFile, gboolean};
 
 #[cfg(windows)]
 pub type GPid = *mut c_void;
@@ -27,4 +28,12 @@ pub struct GPollFD {
     pub fd: c_int,
     pub events: c_ushort,
     pub revents: c_ushort,
+}
+
+extern "C" {
+    pub fn g_key_file_set_boolean_list(key_file: *mut GKeyFile, group_name: *const c_char, key: *const c_char, list: *mut gboolean, length: size_t);
+    pub fn g_key_file_set_double_list(key_file: *mut GKeyFile, group_name: *const c_char, key: *const c_char, list: *mut c_double, length: size_t);
+    pub fn g_key_file_set_integer_list(key_file: *mut GKeyFile, group_name: *const c_char, key: *const c_char, list: *mut c_int, length: size_t);
+    pub fn g_key_file_set_locale_string_list(key_file: *mut GKeyFile, group_name: *const c_char, key: *const c_char, locale: *const c_char, list: *const *const c_char, length: size_t);
+    pub fn g_key_file_set_string_list(key_file: *mut GKeyFile, group_name: *const c_char, key: *const c_char, list: *const *const c_char, length: size_t);
 }

--- a/gobject-sys/src/lib.rs
+++ b/gobject-sys/src/lib.rs
@@ -7,6 +7,10 @@
 extern crate libc;
 extern crate glib_sys as glib;
 
+mod manual;
+
+pub use manual::*;
+
 #[allow(unused_imports)]
 use libc::{c_int, c_char, c_uchar, c_float, c_uint, c_double,
     c_short, c_ushort, c_long, c_ulong,
@@ -1563,8 +1567,6 @@ extern "C" {
     pub fn g_object_get_type() -> GType;
     pub fn g_object_new(object_type: GType, first_property_name: *const c_char, ...) -> *mut GObject;
     //pub fn g_object_new_valist(object_type: GType, first_property_name: *const c_char, var_args: /*Unimplemented*/va_list) -> *mut GObject;
-    #[cfg(any(feature = "v2_54", feature = "dox"))]
-    pub fn g_object_new_with_properties(object_type: GType, n_properties: c_uint, names: *mut c_char, values: GValue) -> *mut GObject;
     pub fn g_object_newv(object_type: GType, n_parameters: c_uint, parameters: *mut GParameter) -> *mut GObject;
     pub fn g_object_compat_control(what: size_t, data: gpointer) -> size_t;
     pub fn g_object_interface_find_property(g_iface: gpointer, property_name: *const c_char) -> *mut GParamSpec;
@@ -1588,8 +1590,6 @@ extern "C" {
     pub fn g_object_get_property(object: *mut GObject, property_name: *const c_char, value: *mut GValue);
     pub fn g_object_get_qdata(object: *mut GObject, quark: glib::GQuark) -> gpointer;
     //pub fn g_object_get_valist(object: *mut GObject, first_property_name: *const c_char, var_args: /*Unimplemented*/va_list);
-    #[cfg(any(feature = "v2_54", feature = "dox"))]
-    pub fn g_object_getv(object: *mut GObject, n_properties: c_uint, names: *mut c_char, values: GValue);
     pub fn g_object_is_floating(object: *mut GObject) -> gboolean;
     pub fn g_object_notify(object: *mut GObject, property_name: *const c_char);
     pub fn g_object_notify_by_pspec(object: *mut GObject, pspec: *mut GParamSpec);
@@ -1609,8 +1609,6 @@ extern "C" {
     pub fn g_object_set_qdata(object: *mut GObject, quark: glib::GQuark, data: gpointer);
     pub fn g_object_set_qdata_full(object: *mut GObject, quark: glib::GQuark, data: gpointer, destroy: glib::GDestroyNotify);
     //pub fn g_object_set_valist(object: *mut GObject, first_property_name: *const c_char, var_args: /*Unimplemented*/va_list);
-    #[cfg(any(feature = "v2_54", feature = "dox"))]
-    pub fn g_object_setv(object: *mut GObject, n_properties: c_uint, names: *mut c_char, values: GValue);
     pub fn g_object_steal_data(object: *mut GObject, key: *const c_char) -> gpointer;
     pub fn g_object_steal_qdata(object: *mut GObject, quark: glib::GQuark) -> gpointer;
     pub fn g_object_thaw_notify(object: *mut GObject);

--- a/gobject-sys/src/manual.rs
+++ b/gobject-sys/src/manual.rs
@@ -1,0 +1,17 @@
+// Copyright 2013-2018, The Gtk-rs Project Developers.
+// See the COPYRIGHT file at the top-level directory of this distribution.
+// Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
+
+#[allow(unused_imports)]
+use libc::{c_char, c_uint};
+#[allow(unused_imports)]
+use {GObject, GType, GValue};
+
+extern "C" {
+    #[cfg(any(feature = "v2_54", feature = "dox"))]
+    pub fn g_object_new_with_properties(object_type: GType, n_properties: c_uint, names: *mut *const c_char, values: *const GValue) -> *mut GObject;
+    #[cfg(any(feature = "v2_54", feature = "dox"))]
+    pub fn g_object_getv(object: *mut GObject, n_properties: c_uint, names: *mut *const c_char, values: *mut GValue);
+    #[cfg(any(feature = "v2_54", feature = "dox"))]
+    pub fn g_object_setv(object: *mut GObject, n_properties: c_uint, names: *mut *const c_char, values: *const GValue);
+}

--- a/gtk-sys/src/lib.rs
+++ b/gtk-sys/src/lib.rs
@@ -16278,12 +16278,8 @@ extern "C" {
     #[cfg(any(feature = "v3_14", feature = "dox"))]
     pub fn gtk_icon_theme_add_resource_path(icon_theme: *mut GtkIconTheme, path: *const c_char);
     pub fn gtk_icon_theme_append_search_path(icon_theme: *mut GtkIconTheme, path: *mut c_char);
-    pub fn gtk_icon_theme_choose_icon(icon_theme: *mut GtkIconTheme, icon_names: *mut c_char, size: c_int, flags: GtkIconLookupFlags) -> *mut GtkIconInfo;
-    #[cfg(any(feature = "v3_10", feature = "dox"))]
-    pub fn gtk_icon_theme_choose_icon_for_scale(icon_theme: *mut GtkIconTheme, icon_names: *mut c_char, size: c_int, scale: c_int, flags: GtkIconLookupFlags) -> *mut GtkIconInfo;
     pub fn gtk_icon_theme_get_example_icon_name(icon_theme: *mut GtkIconTheme) -> *mut c_char;
     pub fn gtk_icon_theme_get_icon_sizes(icon_theme: *mut GtkIconTheme, icon_name: *const c_char) -> *mut c_int;
-    pub fn gtk_icon_theme_get_search_path(icon_theme: *mut GtkIconTheme, path: *mut *mut c_char, n_elements: *mut c_int);
     pub fn gtk_icon_theme_has_icon(icon_theme: *mut GtkIconTheme, icon_name: *const c_char) -> gboolean;
     pub fn gtk_icon_theme_list_contexts(icon_theme: *mut GtkIconTheme) -> *mut glib::GList;
     pub fn gtk_icon_theme_list_icons(icon_theme: *mut GtkIconTheme, context: *const c_char) -> *mut glib::GList;
@@ -16302,7 +16298,6 @@ extern "C" {
     pub fn gtk_icon_theme_rescan_if_needed(icon_theme: *mut GtkIconTheme) -> gboolean;
     pub fn gtk_icon_theme_set_custom_theme(icon_theme: *mut GtkIconTheme, theme_name: *const c_char);
     pub fn gtk_icon_theme_set_screen(icon_theme: *mut GtkIconTheme, screen: *mut gdk::GdkScreen);
-    pub fn gtk_icon_theme_set_search_path(icon_theme: *mut GtkIconTheme, path: *mut c_char, n_elements: c_int);
 
     //=========================================================================
     // GtkIconView

--- a/gtk-sys/src/manual.rs
+++ b/gtk-sys/src/manual.rs
@@ -2,7 +2,17 @@
 // See the COPYRIGHT file at the top-level directory of this distribution.
 // Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
 
+use libc::{c_char, c_int};
+use {GtkIconInfo, GtkIconLookupFlags, GtkIconTheme};
 
 pub mod xlib {
     pub type Window = i32;
+}
+
+extern "C" {
+    pub fn gtk_icon_theme_choose_icon(icon_theme: *mut GtkIconTheme, icon_names: *mut *const c_char, size: c_int, flags: GtkIconLookupFlags) -> *mut GtkIconInfo;
+    #[cfg(any(feature = "v3_10", feature = "dox"))]
+    pub fn gtk_icon_theme_choose_icon_for_scale(icon_theme: *mut GtkIconTheme, icon_names: *mut *const c_char, size: c_int, scale: c_int, flags: GtkIconLookupFlags) -> *mut GtkIconInfo;
+    pub fn gtk_icon_theme_get_search_path(icon_theme: *mut GtkIconTheme, path: *mut *mut *mut c_char, n_elements: *mut c_int);
+    pub fn gtk_icon_theme_set_search_path(icon_theme: *mut GtkIconTheme, path: *mut *const c_char, n_elements: c_int);
 }


### PR DESCRIPTION
Issue #92 

These sys functions have the wrong definition because the GIR files have incorrect array tags due to issue 189 in gi-introspection.  It occurs when the C function definition uses the `[]` operator in a parameter.  I've searched through header files and these are the only functions that I could find.  It's possible that I missed some though.