### PR TITLE
Expose path to headers to other build scripts

### DIFF
--- a/glib-sys/build.rs
+++ b/glib-sys/build.rs
@@ -42,6 +42,10 @@ fn find() -> Result<(), Error> {
         "2.32"
     };
 
+    if let Ok(include_dir) = env::var("GTK_INCLUDE_DIR") {
+        println!("cargo:include={}", include_dir);
+    }
+
     if let Ok(lib_dir) = env::var("GTK_LIB_DIR") {
         for lib_ in shared_libs.iter() {
             println!("cargo:rustc-link-lib=dylib={}", lib_);
@@ -61,6 +65,10 @@ fn find() -> Result<(), Error> {
     }
     match config.probe(package_name) {
         Ok(library) => {
+            if let Ok(paths) = std::env::join_paths(library.include_paths) {
+                // Exposed to other build scripts as DEP_GLIB_INCLUDE; use env::split_paths
+                println!("cargo:include={}", paths.to_string_lossy());
+            }
             if hardcode_shared_libs {
                 for lib_ in shared_libs.iter() {
                     println!("cargo:rustc-link-lib=dylib={}", lib_);


### PR DESCRIPTION
Other sys crates that have C code also need the headers.