### PR TITLE
Fixed IPv6 SocketFamily with wrong value on MacOS and Windows

### DIFF
--- a/conf/gir-gio.toml
+++ b/conf/gir-gio.toml
@@ -42,3 +42,7 @@ version = "2.46"
 [[object]]
 name = "Gio.SocketFamily"
 status = "manual"
+
+[[object]]
+name = "Gio.SocketMsgFlags"
+status = "manual"

--- a/conf/gir-gio.toml
+++ b/conf/gir-gio.toml
@@ -38,3 +38,7 @@ version = "2.44"
 name = "Gio.NativeSocketAddress"
 status = "generate"
 version = "2.46"
+
+[[object]]
+name = "Gio.SocketFamily"
+status = "manual"

--- a/gio-sys/Cargo.toml
+++ b/gio-sys/Cargo.toml
@@ -9,9 +9,9 @@ path = "../glib-sys"
 
 [dependencies.gobject-sys]
 path = "../gobject-sys"
-
-[target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3.9", features = ["ws2def"] }
+[target."cfg(windows)".dependencies.winapi]
+version = "0.3.9"
+features = ["ws2def"]
 
 [dev-dependencies]
 shell-words = "0.1.0"

--- a/gio-sys/Cargo.toml
+++ b/gio-sys/Cargo.toml
@@ -11,7 +11,7 @@ path = "../glib-sys"
 path = "../gobject-sys"
 
 [target.'cfg(windows)'.dependencies]
-winapi = "0.3.9"
+winapi = { version = "0.3.9", features = ["ws2def"] }
 
 [dev-dependencies]
 shell-words = "0.1.0"

--- a/gio-sys/Cargo.toml
+++ b/gio-sys/Cargo.toml
@@ -10,6 +10,9 @@ path = "../glib-sys"
 [dependencies.gobject-sys]
 path = "../gobject-sys"
 
+[target.'cfg(windows)'.dependencies]
+winapi = "0.3.9"
+
 [dev-dependencies]
 shell-words = "0.1.0"
 tempfile = "3"
@@ -42,10 +45,8 @@ links = "gio"
 name = "gio-sys"
 repository = "https://github.com/gtk-rs/sys"
 version = "0.10.0"
-
 [package.metadata.docs.rs]
 features = ["dox"]
-
 [package.metadata.system-deps.gio_2_0]
 name = "gio-2.0"
 version = "2.42"

--- a/gio-sys/Cargo.toml
+++ b/gio-sys/Cargo.toml
@@ -9,9 +9,10 @@ path = "../glib-sys"
 
 [dependencies.gobject-sys]
 path = "../gobject-sys"
+
 [target."cfg(windows)".dependencies.winapi]
 version = "0.3.9"
-features = ["ws2def"]
+features = ["ws2def", "winsock2"]
 
 [dev-dependencies]
 shell-words = "0.1.0"

--- a/gio-sys/src/lib.rs
+++ b/gio-sys/src/lib.rs
@@ -13,6 +13,10 @@ extern crate glib_sys as glib;
 extern crate gobject_sys as gobject;
 extern crate libc;
 
+mod manual;
+
+pub use manual::*;
+
 #[allow(unused_imports)]
 use libc::{
     c_char, c_double, c_float, c_int, c_long, c_short, c_uchar, c_uint, c_ulong, c_ushort, c_void,
@@ -293,12 +297,6 @@ pub const G_SOCKET_CLIENT_PROXY_NEGOTIATED: GSocketClientEvent = 5;
 pub const G_SOCKET_CLIENT_TLS_HANDSHAKING: GSocketClientEvent = 6;
 pub const G_SOCKET_CLIENT_TLS_HANDSHAKED: GSocketClientEvent = 7;
 pub const G_SOCKET_CLIENT_COMPLETE: GSocketClientEvent = 8;
-
-pub type GSocketFamily = c_int;
-pub const G_SOCKET_FAMILY_INVALID: GSocketFamily = 0;
-pub const G_SOCKET_FAMILY_UNIX: GSocketFamily = 1;
-pub const G_SOCKET_FAMILY_IPV4: GSocketFamily = 2;
-pub const G_SOCKET_FAMILY_IPV6: GSocketFamily = 10;
 
 pub type GSocketListenerEvent = c_int;
 pub const G_SOCKET_LISTENER_BINDING: GSocketListenerEvent = 0;

--- a/gio-sys/src/lib.rs
+++ b/gio-sys/src/lib.rs
@@ -749,12 +749,6 @@ pub const G_SETTINGS_BIND_NO_SENSITIVITY: GSettingsBindFlags = 4;
 pub const G_SETTINGS_BIND_GET_NO_CHANGES: GSettingsBindFlags = 8;
 pub const G_SETTINGS_BIND_INVERT_BOOLEAN: GSettingsBindFlags = 16;
 
-pub type GSocketMsgFlags = c_uint;
-pub const G_SOCKET_MSG_NONE: GSocketMsgFlags = 0;
-pub const G_SOCKET_MSG_OOB: GSocketMsgFlags = 1;
-pub const G_SOCKET_MSG_PEEK: GSocketMsgFlags = 2;
-pub const G_SOCKET_MSG_DONTROUTE: GSocketMsgFlags = 4;
-
 pub type GSubprocessFlags = c_uint;
 pub const G_SUBPROCESS_FLAGS_NONE: GSubprocessFlags = 0;
 pub const G_SUBPROCESS_FLAGS_STDIN_PIPE: GSubprocessFlags = 1;

--- a/gio-sys/src/manual.rs
+++ b/gio-sys/src/manual.rs
@@ -29,7 +29,6 @@ mod windows_constants {
 
 #[cfg(not(target_family = "windows"))]
 mod libc_constants {
-
     pub const G_SOCKET_FAMILY_INVALID: super::GSocketFamily = libc::AF_UNSPEC;
     pub const G_SOCKET_FAMILY_UNIX: super::GSocketFamily = libc::AF_UNIX;
     pub const G_SOCKET_FAMILY_IPV4: super::GSocketFamily = libc::AF_INET;

--- a/gio-sys/src/manual.rs
+++ b/gio-sys/src/manual.rs
@@ -1,0 +1,12 @@
+// Copyright 2013-2020, The Gtk-rs Project Developers.
+// See the COPYRIGHT file at the top-level directory of this distribution.
+// Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
+
+use libc;
+use libc::c_int;
+
+pub type GSocketFamily = c_int;
+pub const G_SOCKET_FAMILY_INVALID: GSocketFamily = 0;
+pub const G_SOCKET_FAMILY_UNIX: GSocketFamily = 1;
+pub const G_SOCKET_FAMILY_IPV4: GSocketFamily = libc::AF_INET;
+pub const G_SOCKET_FAMILY_IPV6: GSocketFamily = libc::AF_INET6;

--- a/gio-sys/src/manual.rs
+++ b/gio-sys/src/manual.rs
@@ -3,14 +3,40 @@
 // Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
 
 #[cfg(not(target_family = "windows"))]
-use libc as af_constants;
+pub use self::libc_constants::*;
 #[cfg(target_family = "windows")]
-extern crate winapi;
-#[cfg(target_family = "windows")]
-use self::winapi::shared::ws2def as af_constants;
+pub use self::windows_constants::*;
 
 pub type GSocketFamily = libc::c_int;
-pub const G_SOCKET_FAMILY_INVALID: GSocketFamily = af_constants::AF_UNSPEC;
-pub const G_SOCKET_FAMILY_UNIX: GSocketFamily = af_constants::AF_UNIX;
-pub const G_SOCKET_FAMILY_IPV4: GSocketFamily = af_constants::AF_INET;
-pub const G_SOCKET_FAMILY_IPV6: GSocketFamily = af_constants::AF_INET6;
+pub type GSocketMsgFlags = libc::c_int;
+
+#[cfg(target_family = "windows")]
+mod windows_constants {
+    extern crate winapi;
+
+    pub const G_SOCKET_FAMILY_INVALID: super::GSocketFamily =
+        self::winapi::shared::ws2def::AF_UNSPEC;
+    pub const G_SOCKET_FAMILY_UNIX: super::GSocketFamily = self::winapi::shared::ws2def::AF_UNIX;
+    pub const G_SOCKET_FAMILY_IPV4: super::GSocketFamily = self::winapi::shared::ws2def::AF_INET;
+    pub const G_SOCKET_FAMILY_IPV6: super::GSocketFamily = self::winapi::shared::ws2def::AF_INET6;
+
+    pub const G_SOCKET_MSG_NONE: super::GSocketMsgFlags = 0;
+    pub const G_SOCKET_MSG_OOB: super::GSocketMsgFlags = self::winapi::um::winsock2::MSG_OOB;
+    pub const G_SOCKET_MSG_PEEK: super::GSocketMsgFlags = self::winapi::um::winsock2::MSG_PEEK;
+    pub const G_SOCKET_MSG_DONTROUTE: super::GSocketMsgFlags =
+        self::winapi::um::winsock2::MSG_DONTROUTE;
+}
+
+#[cfg(not(target_family = "windows"))]
+mod libc_constants {
+
+    pub const G_SOCKET_FAMILY_INVALID: super::GSocketFamily = libc::AF_UNSPEC;
+    pub const G_SOCKET_FAMILY_UNIX: super::GSocketFamily = libc::AF_UNIX;
+    pub const G_SOCKET_FAMILY_IPV4: super::GSocketFamily = libc::AF_INET;
+    pub const G_SOCKET_FAMILY_IPV6: super::GSocketFamily = libc::AF_INET6;
+
+    pub const G_SOCKET_MSG_NONE: super::GSocketMsgFlags = 0;
+    pub const G_SOCKET_MSG_OOB: super::GSocketMsgFlags = libc::MSG_OOB;
+    pub const G_SOCKET_MSG_PEEK: super::GSocketMsgFlags = libc::MSG_PEEK;
+    pub const G_SOCKET_MSG_DONTROUTE: super::GSocketMsgFlags = libc::MSG_DONTROUTE;
+}

--- a/gio-sys/src/manual.rs
+++ b/gio-sys/src/manual.rs
@@ -2,11 +2,13 @@
 // See the COPYRIGHT file at the top-level directory of this distribution.
 // Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
 
-use libc;
-use libc::c_int;
+#[cfg(not(target_family = "windows"))]
+use libc as af_constants;
+#[cfg(target_family = "windows")]
+use winapi::shared::ws2def as af_constants;
 
-pub type GSocketFamily = c_int;
-pub const G_SOCKET_FAMILY_INVALID: GSocketFamily = 0;
-pub const G_SOCKET_FAMILY_UNIX: GSocketFamily = 1;
-pub const G_SOCKET_FAMILY_IPV4: GSocketFamily = libc::AF_INET;
-pub const G_SOCKET_FAMILY_IPV6: GSocketFamily = libc::AF_INET6;
+pub type GSocketFamily = libc::c_int;
+pub const G_SOCKET_FAMILY_INVALID: super::GSocketFamily = af_constants::AF_UNSPEC;
+pub const G_SOCKET_FAMILY_UNIX: super::GSocketFamily = af_constants::AF_UNIX;
+pub const G_SOCKET_FAMILY_IPV4: super::GSocketFamily = af_constants::AF_INET;
+pub const G_SOCKET_FAMILY_IPV6: super::GSocketFamily = af_constants::AF_INET6;

--- a/gio-sys/src/manual.rs
+++ b/gio-sys/src/manual.rs
@@ -8,7 +8,7 @@ use libc as af_constants;
 use winapi::shared::ws2def as af_constants;
 
 pub type GSocketFamily = libc::c_int;
-pub const G_SOCKET_FAMILY_INVALID: super::GSocketFamily = af_constants::AF_UNSPEC;
-pub const G_SOCKET_FAMILY_UNIX: super::GSocketFamily = af_constants::AF_UNIX;
-pub const G_SOCKET_FAMILY_IPV4: super::GSocketFamily = af_constants::AF_INET;
-pub const G_SOCKET_FAMILY_IPV6: super::GSocketFamily = af_constants::AF_INET6;
+pub const G_SOCKET_FAMILY_INVALID: GSocketFamily = af_constants::AF_UNSPEC;
+pub const G_SOCKET_FAMILY_UNIX: GSocketFamily = af_constants::AF_UNIX;
+pub const G_SOCKET_FAMILY_IPV4: GSocketFamily = af_constants::AF_INET;
+pub const G_SOCKET_FAMILY_IPV6: GSocketFamily = af_constants::AF_INET6;

--- a/gio-sys/src/manual.rs
+++ b/gio-sys/src/manual.rs
@@ -5,7 +5,9 @@
 #[cfg(not(target_family = "windows"))]
 use libc as af_constants;
 #[cfg(target_family = "windows")]
-use winapi::shared::ws2def as af_constants;
+extern crate winapi;
+#[cfg(target_family = "windows")]
+use self::winapi::shared::ws2def as af_constants;
 
 pub type GSocketFamily = libc::c_int;
 pub const G_SOCKET_FAMILY_INVALID: GSocketFamily = af_constants::AF_UNSPEC;


### PR DESCRIPTION
This is a fix for https://github.com/gtk-rs/sys/issues/178 .

- Added a "manual" override for `Gio.SocketFamily` in `conf/gir-gio.toml `
- Added the appropriate values (using libc) in `gio-sys/src/manual.rs`. The values for `AF_INVALID` and `AF_UNIX` are specified as integers as the corresponding values are not exported as constants in libc; that said, I've checked and their values are 0 and 1 in Windows, MacOS and Linux and, I presume, pretty much every other OS being the two earliest values
- Regenerated `gio-sys/src/lib.rs` accordingly (also included in the PR)