### PR TITLE
gtk4: stop linking gsk & gdk against it

### DIFF
--- a/gdk4-sys/Cargo.toml
+++ b/gdk4-sys/Cargo.toml
@@ -39,7 +39,6 @@ description = "FFI bindings to libgdk-4"
 homepage = "http://gtk-rs.org/"
 keywords = ["gdk", "gdk4", "ffi", "gtk-rs", "gnome"]
 license = "MIT"
-links = "gtk-4"
 name = "gdk4-sys"
 repository = "https://github.com/gtk-rs/sys"
 version = "0.1.0"

--- a/gsk4-sys/Cargo.toml
+++ b/gsk4-sys/Cargo.toml
@@ -39,7 +39,6 @@ description = "FFI bindings to libgsk-4"
 homepage = "http://gtk-rs.org/"
 keywords = ["gsk", "ffi", "gtk-rs", "gnome"]
 license = "MIT"
-links = "gtk-4"
 name = "gsk4-sys"
 repository = "https://github.com/gtk-rs/sys"
 version = "0.1.0"


### PR DESCRIPTION
otherwise we get something like below

'the package `gsk4-sys` links to the native library `gtk-4`, but it conflicts with a previous package which links to `gtk-4` as well:'