### PR TITLE
gdkx11: don't mention it links against to gdk3

### DIFF
--- a/gdkx11-sys/Cargo.toml
+++ b/gdkx11-sys/Cargo.toml
@@ -7,7 +7,6 @@ license = "MIT"
 repository = "https://github.com/gtk-rs/sys"
 name = "gdkx11-sys"
 version = "0.10.0"
-links = "gdk-3"
 build = "build.rs"
 edition = "2018"
 [package.metadata.docs.rs]


### PR DESCRIPTION
workaround against cargo's limitation
same as https://github.com/gtk-rs/sys/pull/184